### PR TITLE
Added function to automate acquisition of GHCNd data. Addresses #5.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,12 @@
+# Ignore R workspace files
 .Rproj.user
 .Rhistory
 .RData
 .Ruserdata
+
+# Ignore MacOS directory metadata hidden files
 .DS_Store
+
+#Ignore CSVs
+*.csv
+


### PR DESCRIPTION
It was proposed in #5 that we use [rnoaa](https://github.com/ropensci/rnoaa), but this library is being archived as NOAA made substantial changes to their API. Since we really only need the GHCN data and NOAA exposes this data via HTTPS request, I wrote a quick function to just download and stack the data from [this link](https://www.ncei.noaa.gov/data/global-historical-climatology-network-daily/) per the [data access instructions here](https://www.ncei.noaa.gov/products/land-based-station/global-historical-climatology-network-daily).